### PR TITLE
Add bookmark and recheck features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+\n.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FactCheck AI — Free Online
 
-This repository contains a browser extension skeleton for FactCheck AI. It runs entirely client side, using open data sources and a logged in ChatGPT session to evaluate claims.
+This repository contains a browser extension skeleton for FactCheck AI. It runs entirely client side, using open data sources and a logged in ChatGPT session to evaluate claims. When a ChatGPT login is required the extension opens a tab so you can authenticate and then continues processing. Results can be bookmarked and pages re-checked later.
 
 ## Structure
 
@@ -8,11 +8,11 @@ This repository contains a browser extension skeleton for FactCheck AI. It runs 
 - `src/background.js` – Background service worker
 - `src/content.js` – Content script to extract page text and detect claims
 - `src/worker-detect.js` – WebWorker with ONNX runtime placeholder
-- `src/cache.js` – IndexedDB storage for verdict caching
-- `src/searchLayer.js` – Functions to query DuckDuckGo, Google and Wikipedia
+- `src/cache.js` – IndexedDB storage for verdicts and bookmarks
+- `src/searchLayer.js` – Functions to query DuckDuckGo, Google/Bing, Wikipedia and other open sources
 - `src/chatgpt-evaluator.js` – Automation for ChatGPT DOM interactions
-- `src/popup.html` + `src/popup.js` – Popup UI to start/stop checking
-- `src/sidepanel.html` + `src/sidepanel.js` – Side panel to display results
+ - `src/popup.html` + `src/popup.js` – Popup UI with progress bar and ChatGPT status
+- `src/sidepanel.html` + `src/sidepanel.js` – Side panel with filterable results table and bookmark/re-check buttons
 
 This code is incomplete and provided as a starting point for further development.
 

--- a/src/background.js
+++ b/src/background.js
@@ -3,19 +3,60 @@ chrome.runtime.onInstalled.addListener(() => {
   console.log('FactCheck AI installed');
 });
 
-// Placeholder for interactions with ChatGPT tab
+// Helper to create or reuse the ChatGPT tab
 async function ensureChatGPTTab() {
   const tabs = await chrome.tabs.query({ url: 'https://chat.openai.com/*' });
   if (tabs.length > 0) {
     return tabs[0].id;
   }
-  const tab = await chrome.tabs.create({ url: 'https://chat.openai.com/', active: false });
+  const tab = await chrome.tabs.create({
+    url: 'https://chat.openai.com/',
+    active: false
+  });
   return tab.id;
 }
 
+// Ensure ChatGPT tab exists and report whether user is logged in
+async function ensureChatGPTSession() {
+  const tabId = await ensureChatGPTTab();
+  const [{ result: loginRequired }] = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => !!document.querySelector('input[type="password"]')
+  });
+  if (!loginRequired) {
+    try { await chrome.tabs.hide(tabId); } catch (e) { /* ignore */ }
+  }
+  return { tabId, loginRequired };
+}
+
+let lastScanTabId = null;
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.command === 'open-chatgpt') {
-    ensureChatGPTTab().then(id => sendResponse({ tabId: id }));
+  if (msg.command === 'ensure-chatgpt-session') {
+    ensureChatGPTSession().then(sendResponse);
     return true;
   }
+  if (msg.command === 'show-chatgpt') {
+    chrome.tabs.update(msg.tabId, { active: true });
+  }
+  if (msg.command === 'fc-start') {
+    lastScanTabId = sender.tab?.id || lastScanTabId;
+  }
+  if (msg.command === 'trigger-recheck') {
+    if (lastScanTabId !== null) {
+      chrome.tabs.sendMessage(lastScanTabId, { command: 'recheck-page' });
+    }
+  }
 });
+
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    const url = new URL(details.url);
+    if (!url.searchParams.has('hl')) {
+      url.searchParams.set('hl', chrome.i18n.getUILanguage().split('-')[0]);
+      return { redirectUrl: url.toString() };
+    }
+  },
+  { urls: ['https://www.google.com/search*'], types: ['xmlhttprequest'] },
+  ['blocking']
+);

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,73 @@
+// Simple IndexedDB wrapper for caching verdicts
+const DB_NAME = 'factcheck-cache';
+const STORE = 'verdicts';
+const BOOKMARKS = 'bookmarks';
+const EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 2);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'hash' });
+      }
+      if (!db.objectStoreNames.contains(BOOKMARKS)) {
+        db.createObjectStore(BOOKMARKS, { keyPath: 'url' });
+      }
+    };
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+export async function getCachedVerdict(hash) {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const store = tx.objectStore(STORE);
+    const req = store.get(hash);
+    req.onsuccess = () => {
+      const entry = req.result;
+      if (entry && Date.now() < entry.expiry) {
+        resolve(entry.verdict);
+      } else {
+        resolve(null);
+      }
+    };
+    req.onerror = () => resolve(null);
+  });
+}
+
+export async function storeVerdict(hash, verdict) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    const store = tx.objectStore(STORE);
+    store.put({ hash, verdict, expiry: Date.now() + EXPIRY_MS });
+  });
+}
+
+export async function addBookmark(url, data) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(BOOKMARKS, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    const store = tx.objectStore(BOOKMARKS);
+    store.put({ url, data, saved: Date.now() });
+  });
+}
+
+export async function getBookmarks() {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(BOOKMARKS, 'readonly');
+    const store = tx.objectStore(BOOKMARKS);
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => resolve([]);
+  });
+}

--- a/src/chatgpt-evaluator.js
+++ b/src/chatgpt-evaluator.js
@@ -1,15 +1,11 @@
 // DOM-based interaction with ChatGPT
 export async function evaluateClaim(claim, evidence) {
   return new Promise((resolve) => {
-    chrome.runtime.sendMessage({ command: 'open-chatgpt' }, async (res) => {
-      const tabId = res.tabId;
-
-      const [{ result: loginRequired }] = await chrome.scripting.executeScript({
-        target: { tabId },
-        func: checkLoginForm
-      });
+    chrome.runtime.sendMessage({ command: 'ensure-chatgpt-session' }, async (res) => {
+      const { tabId, loginRequired } = res;
 
       if (loginRequired) {
+        chrome.runtime.sendMessage({ command: 'show-chatgpt', tabId });
         resolve({ error: 'login-required' });
         return;
       }

--- a/src/content.js
+++ b/src/content.js
@@ -1,5 +1,6 @@
 // Content script for FactCheck AI
 console.log('FactCheck AI content script loaded');
+import { getCachedVerdict, storeVerdict } from './cache.js';
 
 // Extract visible text from the page (simplified)
 function extractText() {
@@ -23,16 +24,46 @@ async function runFactCheck() {
   worker.postMessage({ text });
   worker.onmessage = async (e) => {
     const claims = e.data.claims || [];
-    for (const claim of claims) {
-      // TODO: search and evaluate claim via ChatGPT DOM
-      console.log('Claim detected:', claim.text);
+    if (claims.length > 0) {
+      chrome.windows.create({
+        url: chrome.runtime.getURL('sidepanel.html'),
+        type: 'popup', width: 600, height: 400
+      });
+      chrome.runtime.sendMessage({ command: 'fc-start', total: claims.length, pageUrl: location.href });
     }
+    const { scrapeGoogle } = await import(chrome.runtime.getURL('searchLayer.js'));
+    const { evaluateClaim } = await import(chrome.runtime.getURL('chatgpt-evaluator.js'));
+    for (let i = 0; i < claims.length; i++) {
+      const claim = claims[i];
+      console.log('Claim detected:', claim.text);
+      const hashBuf = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(claim.text));
+      const hash = Array.from(new Uint8Array(hashBuf)).map(b => b.toString(16).padStart(2, '0')).join('');
+      const cached = await getCachedVerdict(hash);
+      let result;
+      if (cached) {
+        result = cached;
+      } else {
+        const evidence = await scrapeGoogle(claim.text);
+        result = await evaluateClaim(claim.text, evidence);
+        if (!result.error) {
+          await storeVerdict(hash, result);
+        } else if (result.error === 'login-required') {
+          chrome.runtime.sendMessage({ command: 'chatgpt-login-required' });
+        }
+      }
+      chrome.runtime.sendMessage({ command: 'display-verdict', data: { claim: claim.text, verdict: result.verdict, explanation: result.explanation } });
+      chrome.runtime.sendMessage({ command: 'fc-progress', done: i + 1, total: claims.length });
+    }
+    chrome.runtime.sendMessage({ command: 'fc-done' });
   };
 }
 
 // Example trigger: run when popup sends message
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg.command === 'start-check') {
+    runFactCheck();
+  }
+  if (msg.command === 'recheck-page') {
     runFactCheck();
   }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,17 @@
     "https://api.duckduckgo.com/*",
     "https://chat.openai.com/*",
     "https://www.google.com/*",
-    "https://www.bing.com/*"
+    "https://www.bing.com/*",
+    "https://*.wikidata.org/*",
+    "https://query.wikidata.org/*",
+    "https://dbpedia.org/*",
+    "https://www.politifact.com/*",
+    "https://www.snopes.com/*",
+    "https://api.gdeltproject.org/*",
+    "https://api.crossref.org/*",
+    "https://api.openalex.org/*",
+    "https://web.archive.org/*",
+    "https://webcache.googleusercontent.com/*"
   ],
   "action": { "default_popup": "popup.html" },
   "background": { "service_worker": "background.js" },
@@ -27,6 +37,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://*.wikipedia.org https://api.duckduckgo.com https://chat.openai.com https://www.google.com https://www.bing.com"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://*.wikipedia.org https://api.duckduckgo.com https://chat.openai.com https://www.google.com https://www.bing.com https://query.wikidata.org https://dbpedia.org https://www.politifact.com https://www.snopes.com https://api.gdeltproject.org https://api.crossref.org https://api.openalex.org https://web.archive.org"
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -11,7 +11,9 @@
 <body>
   <button id="start">Check Page</button>
   <button id="stop">Stop</button>
+  <progress id="progress" value="0" max="1" style="width:100%;display:none"></progress>
   <div id="status"></div>
+  <div id="chatgpt"></div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,10 +1,33 @@
+const statusEl = document.getElementById('status');
+const progressEl = document.getElementById('progress');
+const chatgptEl = document.getElementById('chatgpt');
+
 document.getElementById('start').addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.tabs.sendMessage(tabs[0].id, { command: 'start-check' });
   });
-  document.getElementById('status').textContent = 'Running...';
+  statusEl.textContent = 'Running...';
 });
 
 document.getElementById('stop').addEventListener('click', () => {
-  document.getElementById('status').textContent = 'Stopped';
+  statusEl.textContent = 'Stopped';
+  progressEl.style.display = 'none';
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.command === 'fc-start') {
+    progressEl.max = msg.total;
+    progressEl.value = 0;
+    progressEl.style.display = 'block';
+  }
+  if (msg.command === 'fc-progress') {
+    progressEl.value = msg.done;
+  }
+  if (msg.command === 'fc-done') {
+    statusEl.textContent = 'Done';
+    progressEl.style.display = 'none';
+  }
+  if (msg.command === 'chatgpt-login-required') {
+    chatgptEl.textContent = 'ChatGPT login required';
+  }
 });

--- a/src/searchLayer.js
+++ b/src/searchLayer.js
@@ -5,6 +5,67 @@ export async function searchDuckDuckGo(query) {
   return res.json();
 }
 
+export async function fetchWikidataFacts(query) {
+  const sparql = `SELECT ?item ?itemLabel WHERE { ?item ?label "${query}"@en . SERVICE wikibase:label { bd:serviceParam wikibase:language \"en\". } } LIMIT 5`;
+  const url = `https://query.wikidata.org/sparql?format=json&query=${encodeURIComponent(sparql)}`;
+  const res = await fetch(url);
+  return res.json();
+}
+
+export async function fetchDbpediaFacts(query) {
+  const sparql = `SELECT ?s ?p ?o WHERE { ?s rdfs:label "${query}"@en ; ?p ?o } LIMIT 5`;
+  const url = `https://dbpedia.org/sparql?format=application%2Fsparql-results%2Bjson&query=${encodeURIComponent(sparql)}`;
+  const res = await fetch(url);
+  return res.json();
+}
+
+export async function fetchPolitiFactRss() {
+  const res = await fetch('https://www.politifact.com/feeds/latest/');
+  const xml = await res.text();
+  const dom = new DOMParser().parseFromString(xml, 'text/xml');
+  return Array.from(dom.querySelectorAll('item')).map(item => ({
+    title: item.querySelector('title')?.textContent,
+    link: item.querySelector('link')?.textContent,
+    description: item.querySelector('description')?.textContent
+  }));
+}
+
+export async function scrapeBing(query, lang = 'en') {
+  const url = `https://www.bing.com/search?q=${encodeURIComponent(query)}&setlang=${lang}`;
+  const res = await fetch(url);
+  const html = await res.text();
+  const dom = new DOMParser().parseFromString(html, 'text/html');
+  const results = [];
+  dom.querySelectorAll('li.b_algo').forEach(li => {
+    const a = li.querySelector('h2 > a');
+    const title = a?.textContent?.trim();
+    const snippet = li.querySelector('.b_caption p')?.textContent?.trim();
+    const url = a?.href;
+    if (title && snippet && url) {
+      results.push({ title, snippet, url });
+    }
+  });
+  return results;
+}
+
+export async function fetchCrossRef(query) {
+  const url = `https://api.crossref.org/works?query=${encodeURIComponent(query)}&rows=5`;
+  const res = await fetch(url);
+  return res.json();
+}
+
+export async function fetchOpenAlex(query) {
+  const url = `https://api.openalex.org/works?search=${encodeURIComponent(query)}&per-page=5`;
+  const res = await fetch(url);
+  return res.json();
+}
+
+export async function fetchGdelt(query) {
+  const url = `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(query)}&format=json&maxrecords=5`;
+  const res = await fetch(url);
+  return res.json();
+}
+
 export async function fetchWikiSummary(title, lang = 'en') {
   const url = `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
   const res = await fetch(url);
@@ -15,18 +76,19 @@ export async function scrapeGoogle(query, lang = 'en') {
   const url = `https://www.google.com/search?q=${encodeURIComponent(query)}&hl=${lang}&num=10`;
   const res = await fetch(url);
   const html = await res.text();
-  // TODO: parse DOM in sandbox, extract snippet text
   return parseGoogleHtml(html);
 }
 
 export function parseGoogleHtml(html) {
   const dom = new DOMParser().parseFromString(html, 'text/html');
   const results = [];
-  dom.querySelectorAll('.g').forEach(g => {
-    const title = g.querySelector('h3')?.textContent?.trim();
+  dom.querySelectorAll('div.g').forEach(g => {
+    const a = g.querySelector('.yuRUbf > a');
+    const title = a?.querySelector('h3')?.textContent?.trim();
     const snippet = g.querySelector('.IsZvec')?.textContent?.trim();
-    if (title && snippet) {
-      results.push({ title, snippet });
+    const url = a?.href;
+    if (title && snippet && url) {
+      results.push({ title, snippet, url });
     }
   });
   return results;

--- a/src/sidepanel.html
+++ b/src/sidepanel.html
@@ -19,6 +19,18 @@
     </thead>
     <tbody></tbody>
   </table>
-  <script src="sidepanel.js"></script>
+  <label>Filter:
+    <select id="filter">
+      <option value="all">All</option>
+      <option value="support">Support</option>
+      <option value="refute">Refute</option>
+      <option value="notenough">Not enough</option>
+    </select>
+  </label>
+  <div style="margin-top:8px;">
+    <button id="bookmark">Bookmark Page</button>
+    <button id="recheck">Re-check Page</button>
+  </div>
+  <script type="module" src="sidepanel.js"></script>
 </body>
 </html>

--- a/src/sidepanel.js
+++ b/src/sidepanel.js
@@ -1,14 +1,46 @@
-// Placeholder side panel script
+import { addBookmark } from './cache.js';
+
+let pageUrl = '';
+const resultsData = [];
+
+const filterEl = document.getElementById('filter');
+const bookmarkBtn = document.getElementById('bookmark');
+const recheckBtn = document.getElementById('recheck');
+
+filterEl.addEventListener('change', filterRows);
+bookmarkBtn.addEventListener('click', () => {
+  if (pageUrl) addBookmark(pageUrl, resultsData);
+});
+recheckBtn.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ command: 'trigger-recheck' });
+});
+
 chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.command === 'fc-start') {
+    pageUrl = msg.pageUrl;
+  }
   if (msg.command === 'display-verdict') {
     appendResult(msg.data);
+    filterRows();
   }
 });
 
 function appendResult(result) {
+  resultsData.push(result);
   const tbody = document.querySelector('#results tbody');
   const tr = document.createElement('tr');
   tr.className = result.verdict;
   tr.innerHTML = `<td>${result.claim}</td><td>${result.verdict}</td><td>${result.explanation}</td>`;
   tbody.appendChild(tr);
+}
+
+function filterRows() {
+  const val = filterEl.value;
+  document.querySelectorAll('#results tbody tr').forEach(tr => {
+    if (val === 'all' || tr.className === val) {
+      tr.style.display = '';
+    } else {
+      tr.style.display = 'none';
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- extend manifest host permissions and CSP for many new open-data sources
- implement additional search helpers (Wikidata, DBpedia, Bing, CrossRef, etc.)
- cache module now also stores bookmarks
- send page URL with fact-check progress and allow re-checking
- add bookmark and re-check buttons in the side panel
- inject language parameter into Google searches via `webRequest`
- update README with new capabilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841d702f734832a9811aef56ef8e3fd